### PR TITLE
Document offline-first architecture and add service stub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/CoachApp/CoachApp.swift
+++ b/CoachApp/CoachApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct CoachApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/CoachApp/ContentView.swift
+++ b/CoachApp/ContentView.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        TabView {
+            GoalsView()
+                .tabItem {
+                    Image(systemName: "target")
+                    Text("Goals")
+                }
+            ScheduleView()
+                .tabItem {
+                    Image(systemName: "calendar")
+                    Text("Schedule")
+                }
+            ProgramsView()
+                .tabItem {
+                    Image(systemName: "list.bullet")
+                    Text("Programs")
+                }
+            TrackingView()
+                .tabItem {
+                    Image(systemName: "chart.bar")
+                    Text("Tracking")
+                }
+            NutritionView()
+                .tabItem {
+                    Image(systemName: "leaf")
+                    Text("Nutrition")
+                }
+            MessagingView()
+                .tabItem {
+                    Image(systemName: "bubble.left")
+                    Text("Chat")
+                }
+            AnalyticsView()
+                .tabItem {
+                    Image(systemName: "waveform.path.ecg")
+                    Text("Analytics")
+                }
+            AccountView()
+                .tabItem {
+                    Image(systemName: "person.crop.circle")
+                    Text("Account")
+                }
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/CoachApp/Models/Goal.swift
+++ b/CoachApp/Models/Goal.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct Goal: Identifiable {
+    var id = UUID()
+    var title: String
+    var type: GoalType
+}
+
+enum GoalType: String {
+    case weightLoss
+    case muscleGain
+    case toning
+}

--- a/CoachApp/Models/NutritionPlan.swift
+++ b/CoachApp/Models/NutritionPlan.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct NutritionPlan: Identifiable {
+    var id = UUID()
+    var caloriesPerDay: Int
+    var meals: [Meal]
+}
+
+struct Meal: Identifiable {
+    var id = UUID()
+    var title: String
+    var ingredients: [String]
+}

--- a/CoachApp/Models/UserProfile.swift
+++ b/CoachApp/Models/UserProfile.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+struct UserProfile: Identifiable {
+    var id = UUID()
+    var name: String
+    var role: UserRole
+    var goals: [Goal] = []
+    var workouts: [Workout] = []
+}
+
+enum UserRole {
+    case coach
+    case client
+}

--- a/CoachApp/Models/Workout.swift
+++ b/CoachApp/Models/Workout.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+struct Workout: Identifiable {
+    var id = UUID()
+    var name: String
+    var exercises: [Exercise]
+}
+
+struct Exercise: Identifiable {
+    var id = UUID()
+    var title: String
+    var reps: Int
+    var sets: Int
+}

--- a/CoachApp/Services/FirebaseService.swift
+++ b/CoachApp/Services/FirebaseService.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+// Placeholder service simulating Firebase Realtime Database with offline support.
+// In a real app, this would use Firebase SDK to handle authentication,
+// offline persistence, and data synchronization when network is available.
+
+enum DataPath: String {
+    case availability = "/clients/{id}/availability"
+    case sessions = "/sessions"
+    case programs = "/programs"
+    case exercises = "/exercises"
+    case messages = "/messages"
+}
+
+struct QueuedWrite: Identifiable {
+    let id = UUID()
+    let path: DataPath
+    let payload: [String: Any]
+}
+
+class FirebaseService {
+    static let shared = FirebaseService()
+
+    // Simplified token cache
+    private var cachedToken: String?
+
+    // Offline write queue
+    private var writeQueue: [QueuedWrite] = []
+
+    private init() {}
+
+    // MARK: - Authentication
+    func signIn(withToken token: String) {
+        // Normally you would call Firebase Auth here.
+        cachedToken = token
+    }
+
+    func cachedSignIn() -> Bool {
+        // Use cached token when offline.
+        return cachedToken != nil
+    }
+
+    // MARK: - Data Operations
+    func queueWrite(path: DataPath, data: [String: Any]) {
+        let write = QueuedWrite(path: path, payload: data)
+        writeQueue.append(write)
+    }
+
+    func syncIfNeeded() {
+        guard !writeQueue.isEmpty else { return }
+        // In a real implementation, this would push queued writes to Firebase
+        // and clear the queue upon success.
+        writeQueue.removeAll()
+    }
+}

--- a/CoachApp/Views/AccountView.swift
+++ b/CoachApp/Views/AccountView.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct AccountView: View {
+    var body: some View {
+        NavigationView {
+            Text("User profile, subscription, and settings")
+                .navigationTitle("Account")
+        }
+    }
+}
+
+struct AccountView_Previews: PreviewProvider {
+    static var previews: some View {
+        AccountView()
+    }
+}

--- a/CoachApp/Views/AnalyticsView.swift
+++ b/CoachApp/Views/AnalyticsView.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct AnalyticsView: View {
+    var body: some View {
+        NavigationView {
+            Text("Progress dashboards and reports")
+                .navigationTitle("Analytics")
+        }
+    }
+}
+
+struct AnalyticsView_Previews: PreviewProvider {
+    static var previews: some View {
+        AnalyticsView()
+    }
+}

--- a/CoachApp/Views/GoalsView.swift
+++ b/CoachApp/Views/GoalsView.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct GoalsView: View {
+    var body: some View {
+        NavigationView {
+            Text("Goal setup and workout preferences go here")
+                .navigationTitle("Goals")
+        }
+    }
+}
+
+struct GoalsView_Previews: PreviewProvider {
+    static var previews: some View {
+        GoalsView()
+    }
+}

--- a/CoachApp/Views/MessagingView.swift
+++ b/CoachApp/Views/MessagingView.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct MessagingView: View {
+    var body: some View {
+        NavigationView {
+            Text("In-app chat and notifications")
+                .navigationTitle("Chat")
+        }
+    }
+}
+
+struct MessagingView_Previews: PreviewProvider {
+    static var previews: some View {
+        MessagingView()
+    }
+}

--- a/CoachApp/Views/NutritionView.swift
+++ b/CoachApp/Views/NutritionView.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct NutritionView: View {
+    var body: some View {
+        NavigationView {
+            Text("Meal plans, recipes, and supplements")
+                .navigationTitle("Nutrition")
+        }
+    }
+}
+
+struct NutritionView_Previews: PreviewProvider {
+    static var previews: some View {
+        NutritionView()
+    }
+}

--- a/CoachApp/Views/ProgramsView.swift
+++ b/CoachApp/Views/ProgramsView.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct ProgramsView: View {
+    var body: some View {
+        NavigationView {
+            Text("Workout program builder and library")
+                .navigationTitle("Programs")
+        }
+    }
+}
+
+struct ProgramsView_Previews: PreviewProvider {
+    static var previews: some View {
+        ProgramsView()
+    }
+}

--- a/CoachApp/Views/ScheduleView.swift
+++ b/CoachApp/Views/ScheduleView.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct ScheduleView: View {
+    var body: some View {
+        NavigationView {
+            Text("Scheduling and availability")
+                .navigationTitle("Schedule")
+        }
+    }
+}
+
+struct ScheduleView_Previews: PreviewProvider {
+    static var previews: some View {
+        ScheduleView()
+    }
+}

--- a/CoachApp/Views/TrackingView.swift
+++ b/CoachApp/Views/TrackingView.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct TrackingView: View {
+    var body: some View {
+        NavigationView {
+            Text("Workout logging and activity tracking")
+                .navigationTitle("Tracking")
+        }
+    }
+}
+
+struct TrackingView_Previews: PreviewProvider {
+    static var previews: some View {
+        TrackingView()
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version: 6.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "coach_v2",
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .executableTarget(
+            name: "coach_v2"),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# Coach iOS App (SwiftUI)
+
+This repository contains a SwiftUI skeleton for a coach/client fitness application.
+It now demonstrates an **offline-first** architecture inspired by Firebase Realtime Database.
+
+## Features
+
+- Goals & Preferences
+- Schedule & Availability
+- Workout Programs
+- Tracking & Logging
+- Nutrition & Supplements
+- Messaging & Notifications
+- Analytics Dashboard
+- Account Management
+
+Each feature is represented by a SwiftUI view under `CoachApp/Views` and basic data
+models under `CoachApp/Models`.
+
+### Offline Data Paths
+
+| Feature              | Path example                        | Offline behavior                      | Trigger events                      |
+|----------------------|------------------------------------|---------------------------------------|------------------------------------|
+| Auth                 | -                                  | Token cached for auto-login           | -                                  |
+| Client Availability  | `/clients/{id}/availability`        | Writes stored locally                 | Coach fetch on sync                |
+| Session Scheduling   | `/sessions`                         | Writes queued offline                 | Notification then client confirm   |
+| Program Builder      | `/programs`                         | Cached while editing                  | Syncs when saved                   |
+| Exercise Library     | `/exercises`                        | Listed offline                        | Updates via sync                   |
+| Workout Logging      | `/sessions/{id}/logs`               | Queue writes                          | Coach fetch updates                |
+| Messaging            | `/messages`                         | Queued writes                         | Real-time chat after sync          |
+| Push Notifications   | FCM Cloud Functions                | Online only                           | Session/chat events                |
+
+The included `FirebaseService` is a placeholder that demonstrates token caching
+and an offline write queue. In a real project you would integrate Firebase SDKs
+for authentication, Realtime Database, and Cloud Functions for push notifications.
+
+This code is a starting point and not production ready.

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -1,0 +1,4 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book
+
+print("Hello, world!")


### PR DESCRIPTION
## Summary
- introduce `FirebaseService` to simulate offline writes and token cache
- document offline data paths and behavior in README

## Testing
- `swift build`

------
https://chatgpt.com/codex/tasks/task_e_687097f68a80832f99d3a472b7e038d8